### PR TITLE
adding a public field to expose the codebuild project

### DIFF
--- a/API.md
+++ b/API.md
@@ -38,6 +38,12 @@ new ProwlerAudit(parent: Stack, id: string, props?: ProwlerAuditProps)
 
 #### Properties <a name="Properties"></a>
 
+##### `codebuildProject`<sup>Required</sup> <a name="cdk-prowler.ProwlerAudit.property.codebuildProject"></a>
+
+- *Type:* [`@aws-cdk/aws-codebuild.Project`](#@aws-cdk/aws-codebuild.Project)
+
+---
+
 ##### `enableScheduler`<sup>Required</sup> <a name="cdk-prowler.ProwlerAudit.property.enableScheduler"></a>
 
 - *Type:* `boolean`

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export class ProwlerAudit extends Construct {
   prowlerScheduler: string;
   prowlerOptions: string;
   prowlerVersion: string;
+  codebuildProject: codebuild.Project;
 
   constructor(parent: Stack, id: string, props?: ProwlerAuditProps) {
     super(parent, id);
@@ -93,7 +94,7 @@ export class ProwlerAudit extends Construct {
     const reportGroup = new codebuild.ReportGroup(this, 'reportGroup', { /**reportGroupName: 'testReportGroup', */removalPolicy: RemovalPolicy.DESTROY });
     reportGroup;
 
-    const prowlerBuild = new codebuild.Project(this, 'prowlerBuild', {
+    const prowlerBuild = this.codebuildProject = new codebuild.Project(this, 'prowlerBuild', {
       description: 'Run Prowler assessment',
       timeout: Duration.hours(5),
       environment: {


### PR DESCRIPTION
I want to reference the codebuild project so I can trigger it from an EventBridge rule, so added a public property.